### PR TITLE
Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recipe",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recipe",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@prisma/client": "^5.2.0",
         "@types/node": "20.5.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recipe",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/search-button.tsx
+++ b/src/components/search-button.tsx
@@ -51,7 +51,7 @@ export default function SearchButton(props: SearchButtonProps) {
         }
     }
 
-    const useSearch = (post: PostUI) => {
+    const searchedPostUse = (post: PostUI) => {
         closeSearch();
         props.callback(post);
     }
@@ -66,7 +66,7 @@ export default function SearchButton(props: SearchButtonProps) {
             <Button
                 value={'Use'}
                 active={true}
-                onClick={() => useSearch(post)}
+                onClick={() => searchedPostUse(post)}
                 style={{ margin: '5px', marginBottom: '25px', marginRight: '20px', float: 'right' }}
             />
         );


### PR DESCRIPTION
Compilation revealed 'use<function-name>' for seemingly any valid string <function-name> will be treated as a react hook even if it is not. This meant compiling 'useSearch' was not allowed since it was used in a callback function even though it is not a react hook!! This is fixed simply by renaming the function...